### PR TITLE
[FIX] Nullptr dereference

### DIFF
--- a/src/base/ftobjs.c
+++ b/src/base/ftobjs.c
@@ -2944,7 +2944,7 @@
 
 
     error = FT_ERR( Invalid_Face_Handle );
-    if ( face && face->driver )
+    if ( face && face->driver && face->internal)
     {
       face->internal->refcount--;
       if ( face->internal->refcount > 0 )


### PR DESCRIPTION
I encountered a nullptr dereference when calling FT_Done_Face (through `TTF_CloseFont()`) here. `face->internal` was null, when I used SDL 3.2.0 and SDL_ttf to create a font from SDL_IOStream, where as the IOStream was a SDL_IOFromConstMem().

This might not be the best solution, just the one solution that did not further upset the MSVC ASAN.